### PR TITLE
feat: create arrows

### DIFF
--- a/lib/mural/client/mural_content.rb
+++ b/lib/mural/client/mural_content.rb
@@ -5,6 +5,7 @@ module Mural
     class MuralContent
       extend Forwardable
 
+      include Arrows
       include Chats
       include FacilitationFeatures
       include Files

--- a/lib/mural/client/mural_content/arrows.rb
+++ b/lib/mural/client/mural_content/arrows.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Mural
+  class Client
+    class MuralContent
+      module Arrows
+        # https://developers.mural.co/public/reference/createarrow
+        def create_arrow(mural_id, create_arrow_params)
+          json = post(
+            "/api/public/v1/murals/#{mural_id}/widgets/arrow",
+            create_arrow_params.encode
+          )
+
+          Mural::Widget::Arrow.decode(json['value'])
+        end
+      end
+    end
+  end
+end

--- a/lib/mural/widget/arrow.rb
+++ b/lib/mural/widget/arrow.rb
@@ -88,6 +88,13 @@ module Mural
           end
         end
 
+        def encode
+          super.tap do |json|
+            json['format'] = json['format']&.encode
+            json['labels']&.map!(&:encode)
+          end.compact
+        end
+
         class Format
           include Mural::Codec
 

--- a/lib/mural/widget/create_arrow_params.rb
+++ b/lib/mural/widget/create_arrow_params.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Mural
+  class Widget
+    class CreateArrowParams
+      include Mural::Codec
+
+      # https://developers.mural.co/public/reference/createarrow
+      define_attributes(
+        **Mural::Widget::Arrow.attrs.reject do |attr|
+          %i[
+            content_edited_by
+            content_edited_on
+            created_by
+            created_on
+            hidden
+            hide_editor
+            hide_owner
+            id
+            invisible
+            locked
+            locked_by_facilitator
+            type
+            updated_by
+            updated_on
+          ].include? attr
+        end
+      )
+
+      def encode
+        super.tap do |json|
+          json['points']&.map!(&:encode)
+          json['label'] = json['label']&.encode
+          json['style'] = json['style']&.encode
+        end
+      end
+
+      Style = Mural::Widget::Arrow::Style
+      Label = Mural::Widget::Arrow::Label
+      Point = Mural::Widget::Arrow::Point
+    end
+  end
+end

--- a/test/mural/client/mural_content/test_arrows.rb
+++ b/test/mural/client/mural_content/test_arrows.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+class TestArrows < Minitest::Test
+  def setup
+    @client = Mural::Client.new
+  end
+
+  def test_create_minimal_arrow
+    mural_id = 'mural-id'
+
+    stub_request(
+      :post,
+      "https://app.mural.co/api/public/v1/murals/#{mural_id}/widgets/arrow"
+    ).with(
+      body: {
+        height: 1,
+        width: 216,
+        x: 0,
+        y: 0,
+        points: [
+          { x: 216, y: 0 },
+          { x: 0, y: 0 }
+        ]
+      }
+    ).to_return_json(
+      body: { value: { id: 'arrow-1' } },
+      status: 201
+    )
+
+    create_arrow_params = Mural::Widget::CreateArrowParams.new.tap do |params|
+      params.height = 1
+      params.width = 216
+      params.x = 0
+      params.y = 0
+
+      params.points = [
+        Mural::Widget::Arrow::Point.new.tap do |p|
+          p.x = 216
+          p.y = 0
+        end,
+        Mural::Widget::Arrow::Point.new.tap do |p|
+          p.x = 0
+          p.y = 0
+        end
+      ]
+    end
+
+    arrow = @client.mural_content.create_arrow(mural_id, create_arrow_params)
+
+    assert_instance_of Mural::Widget::Arrow, arrow
+    assert_equal 'arrow-1', arrow.id
+  end
+
+  def test_create_arrow_without_points
+    mural_id = 'mural-id'
+
+    stub_request(
+      :post,
+      "https://app.mural.co/api/public/v1/murals/#{mural_id}/widgets/arrow"
+    ).with(
+      body: {
+        height: 1,
+        width: 216,
+        x: 0,
+        y: 0
+      }
+    ).to_return_json(
+      body: {
+        message: 'Invalid payload',
+        code: 'BODY',
+        details: [
+          {
+            code: 'Invalid property',
+            message: 'Invalid "points" property type was sent. Type array ' \
+                     'was expected.'
+          }
+        ]
+      },
+      status: 400
+    )
+
+    create_arrow_params = Mural::Widget::CreateArrowParams.new.tap do |params|
+      params.height = 1
+      params.width = 216
+      params.x = 0
+      params.y = 0
+    end
+
+    assert_raises(Mural::Error) do
+      @client.mural_content.create_arrow(mural_id, create_arrow_params)
+    end
+  end
+
+  def test_create_arrow_with_style_and_formatted_label
+    mural_id = 'mural-id'
+
+    stub_request(
+      :post,
+      "https://app.mural.co/api/public/v1/murals/#{mural_id}/widgets/arrow"
+    ).with(
+      body: {
+        height: 1,
+        width: 216,
+        x: 0,
+        y: 0,
+        points: [
+          { x: 216, y: 0 },
+          { x: 0, y: 0 }
+        ],
+        style: { strokeColor: '#FAFAFAFF' },
+        label: { format: { fontFamily: 'proxima-nova' } }
+      }
+    ).to_return_json(
+      body: { value: { id: 'arrow-1' } },
+      status: 201
+    )
+
+    create_arrow_params = Mural::Widget::CreateArrowParams.new.tap do |params|
+      params.height = 1
+      params.width = 216
+      params.x = 0
+      params.y = 0
+
+      params.points = [
+        Mural::Widget::Arrow::Point.new.tap do |p|
+          p.x = 216
+          p.y = 0
+        end,
+        Mural::Widget::Arrow::Point.new.tap do |p|
+          p.x = 0
+          p.y = 0
+        end
+      ]
+
+      params.style = Mural::Widget::CreateArrowParams::Style.new.tap do |style|
+        style.stroke_color = '#FAFAFAFF'
+      end
+
+      params.label = Mural::Widget::CreateArrowParams::Label.new.tap do |label|
+        label.format =
+          Mural::Widget::CreateArrowParams::Label::Format.new.tap do |format|
+            format.font_family = 'proxima-nova'
+          end
+      end
+    end
+
+    arrow = @client.mural_content.create_arrow(mural_id, create_arrow_params)
+
+    assert_instance_of Mural::Widget::Arrow, arrow
+    assert_equal 'arrow-1', arrow.id
+  end
+
+  def test_create_arrow_with_unformatted_labels
+    mural_id = 'mural-id'
+
+    stub_request(
+      :post,
+      "https://app.mural.co/api/public/v1/murals/#{mural_id}/widgets/arrow"
+    ).with(
+      body: {
+        height: 1,
+        width: 216,
+        x: 0,
+        y: 0,
+        points: [
+          { x: 216, y: 0 },
+          { x: 0, y: 0 }
+        ],
+        label: {
+          labels: [
+            { x: 0, y: 0, height: 12, width: 100, text: 'Arrow label' }
+          ]
+        }
+      }
+    ).to_return_json(
+      body: { value: { id: 'arrow-1' } },
+      status: 201
+    )
+
+    create_arrow_params = Mural::Widget::CreateArrowParams.new.tap do |params|
+      params.height = 1
+      params.width = 216
+      params.x = 0
+      params.y = 0
+
+      params.points = [
+        Mural::Widget::Arrow::Point.new.tap do |p|
+          p.x = 216
+          p.y = 0
+        end,
+        Mural::Widget::Arrow::Point.new.tap do |p|
+          p.x = 0
+          p.y = 0
+        end
+      ]
+
+      params.label = Mural::Widget::CreateArrowParams::Label.new.tap do |label|
+        label.labels = [
+          Mural::Widget::CreateArrowParams::Label::Label.new.tap do |l|
+            l.x = 0
+            l.y = 0
+            l.height = 12
+            l.width = 100
+            l.text = 'Arrow label'
+          end
+        ]
+      end
+    end
+
+    arrow = @client.mural_content.create_arrow(mural_id, create_arrow_params)
+
+    assert_instance_of Mural::Widget::Arrow, arrow
+    assert_equal 'arrow-1', arrow.id
+  end
+end


### PR DESCRIPTION
Implement [create an arrow on a mural](https://developers.mural.co/public/reference/createarrow).

This is the base behavior. What we need then is to implement something at a higher-level, like a "connect those two widgets" function to build the proper payload.